### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,7 @@ This will use our seed examples to generate high-quality training data that foll
 To fine-tune a base model with a specific persona:
 
 ```bash
-python scripts/fine_tune_persona.py \
-    --model_id "microsoft/phi-4-mini-instruct" \
-    --dataset_path "persona_data/captain_codebeard.jsonl" \
-    --persona_name "captain_codebeard" \
-    --output_dir "trained_adapters"
+uv run scripts/fine_tune_persona.py --model_id "microsoft/phi-4-mini-instruct" --dataset_path "leonvanbokhorst/tame-the-weights-personas" --persona_name "captain_codebeard" --output_dir "trained_adapters"
 ```
 
 Additional options:


### PR DESCRIPTION
## Summary by Sourcery

Update README example for fine-tuning a persona to use `uv run` and reference the new dataset path

Documentation:
- Update the fine-tune persona command to use `uv run` instead of `python`
- Change the dataset path in the README example to `leonvanbokhorst/tame-the-weights-personas` and consolidate the flags into a single-line invocation